### PR TITLE
errbot-k8s v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 MAINTAINER andrew.the.techie@gmail.com
-LABEL description="Docker image for running errbot in kubernetes"
+LABEL description="Docker image for running errbot in kubernetes, customized for the SA Devz"
 
 COPY ./errbot /errbot
 RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential libssl-dev libffi-dev && \
-    pip3 install --no-cache-dir -r /errbot/requirements.txt && \
+    python -m venv /errbot/venv && \
+    . /errbot/venv/bin/activate && \
+    /errbot/venv/bin/pip install --no-cache-dir -r /errbot/requirements.txt && \
+    /errbot/venv/bin/pip install --no-cache-dir -r /errbot/plugin-requirements.txt && \
+    rm -rf /errbot/*requirements.txt && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /errbot
-CMD errbot -c config.py
+
+ENTRYPOINT ["/errbot/run.sh"]

--- a/errbot/install_plugins.py
+++ b/errbot/install_plugins.py
@@ -1,0 +1,79 @@
+import os
+import pathlib
+import sys
+import logging
+from dulwich import porcelain
+
+confg = None
+log = logging.getLogger()
+
+def load_config():
+    global config
+    pre_config_log = logging.getLogger()
+    execution_dir = os.getcwd()
+    sys.path.insert(0, execution_dir)
+    config_path = execution_dir + '/' + 'config.py'
+
+    if not os.path.exists(config_path):
+        pre_config_log.error(f"Cannot find the config file {config_path}")
+        exit(1)
+
+    loaded_config = None
+    try:
+        loaded_config = __import__(os.path.splitext(os.path.basename(config_path))[0])
+        pre_config_log.info('Bot config loaded.')
+    except Exception as exc:
+        pre_config_log.exception(f"Unable to load config file {config_path}")
+        pre_config_log.exception(str(exc))
+        exit(1)
+
+    config = loaded_config
+    return loaded_config
+
+
+def clone_repos(base_dir: str, repos: list) -> None:
+    """
+    Clones repositories from a list (repos) into a directory (base_dir)
+    Args:
+        base_dir (str):
+        repos:
+
+    Returns:
+
+    """
+    # if we don't have any configured repos, nothing to clone
+    if len(repos) == 0:
+        return
+
+    for repo_config in repos:
+        print(repo_config)
+        repo_config = repo_config.split(',')
+        repo_loc = f"{base_dir}/{repo_config[0]}"
+        log.debug("repo_location: %s", repo_loc)
+        print(repo_loc)
+        # If the repo exists, delete it, we'll clone it clean and then create the path for us to clone into
+        if os.path.exists(repo_loc):
+            log.debug("Repo exists, pulling %s", repo_loc)
+            try:
+                porcelain.pull(repo_loc)
+            except porcelain.Error as exc:
+                log.error("Exception pulling %s. Error: %s", repo_loc, str(exc))
+            break
+
+        pathlib.Path(repo_loc).mkdir(parents=True, exist_ok=True)
+        try:
+            repo = porcelain.clone(repo_config[1], repo_loc)
+            git_config = repo.get_config()
+            git_config.set(('branch', repo_config[2]), 'remote', 'origin')
+            git_config.set(('branch', repo_config[2]), 'merge', f"refs/heads/{repo_config[2]}")
+            git_config.write_to_path()
+            porcelain.pull(repo_loc)
+            log.info(f"Successfully cloned {repo_config[0]}/{repo_config[2]} to {repo_loc} from {repo_config[1]}")
+        except porcelain.Error as exception:
+            log.error(f"Exception cloning {repo_config[0]} from {repo_config[1]}. Error: {str(exception)}")
+
+
+if __name__ == '__main__':
+    config = load_config()
+    clone_repos(base_dir=config.BOT_EXTRA_PLUGIN_DIR,
+                repos=config.REPOS_LIST)

--- a/errbot/plugin-requirements.txt
+++ b/errbot/plugin-requirements.txt
@@ -1,0 +1,4 @@
+# add any requirements for plugins in here and they'll get installed in the base docker image to speed up bot start time
+errbot[slack]
+python-decouple
+wrapt

--- a/errbot/requirements.txt
+++ b/errbot/requirements.txt
@@ -1,8 +1,2 @@
-dataclasses>=0.6
 errbot==6.1.4
-slackclient>=1.0.5,<2.0
-PyGithub==1.43.7
-pyhcl==0.3.12
-ply==3.11
-redis==3.2.1
-healthcheck>=1.3.3
+dulwich

--- a/errbot/run.sh
+++ b/errbot/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set +x
+set -Eeuo pipefail
+
+ERRBOT="/errbot/venv/bin/errbot"
+
+# Execute code to install plugins repos
+eval "/errbot/venv/bin/python /errbot/install_plugins.py"
+
+# Source errbot venv
+echo "Activate virtual environment"
+source /errbot/venv/bin/activate
+
+# Run bot
+echo "Executing: $ERRBOT"
+eval $ERRBOT


### PR DESCRIPTION
v2 addresses a few things:
* errbot's built in plugin manager's repo downloading is pretty weak and was not working
* There was no access controls or ability to implement it in the config. 
* The bot was sending an error message to every bot admin on start when plugins were blacklisted
* We were blacklisting core plugins in the running config to prevent their misuse
* Errbot won't install plugin requirements if its not running in a virtualenv, even when isolated in a docker container

### New Plugin Manager
This implements a very simple plugin downloader using git and install_plugins.py. This will read from an environment variable (PLUGIN_REPOS) and clone each repo on bot startup. 

### Access control
Access control is now supported to be read in from a json file. The plan is to inject this via a k8s configmap so we can do access control. 

### Blacklisted plugins
This trims the core plugins to only the list of plugins we want to run, including removing the `Plugins` plugin (responsible for cloning plugins)

### Moves to a virtualenv
Errbot behaves better in a venv, so lets double isolate this bad boy. That's right, venvs inside of docker. 