### PR TITLE
feat: add a way to install pkgs at runtime

### DIFF
--- a/errbot/run.sh
+++ b/errbot/run.sh
@@ -12,6 +12,12 @@ eval "/errbot/venv/bin/python /errbot/install_plugins.py"
 echo "Activate virtual environment"
 source /errbot/venv/bin/activate
 
+EXTRA_REQUIREMENTS_FILE_PATH=${EXTRA_REQUIREMENTS_FILE:-/config/extra-requirements.txt}
+# install any extra requirements
+if [[ -f "$EXTRA_REQUIREMENTS_FILE_PATH" ]]; then
+    /errbot/venv/bin/pip install -r $EXTRA_REQUIREMENTS_FILE_PATH
+fi
+
 # Run bot
 echo "Executing: $ERRBOT"
 eval $ERRBOT


### PR DESCRIPTION
This adds to the run.sh script to check for a requirements file and run
a pip install of that file if it exists. By default, it looks at
/config/extra-requirements.txt but it can be configured with an
environment variable EXTRA_REQUIREMENTS_FILE to point to any path
